### PR TITLE
docs: fix typo - 'kebab' for 'kebob'

### DIFF
--- a/content/docs/v2/cli/generate/index.md
+++ b/content/docs/v2/cli/generate/index.md
@@ -37,4 +37,4 @@ This will create a standard class with a simple `http` get request using Angular
 
 ### A quick note on naming conventions
 
-Ionic 2 uses kebob-casing for file names (`my-about-page.html`) and css classes (`.my-about-page`), and uses PascalCasing for JavaScript classes in ES6/TypeScript (`MyAboutPage`). Using this convention, developers can pick up any Ionic 2 project and quickly become productive, similar to Rails.
+Ionic 2 uses kebab-casing for file names (`my-about-page.html`) and css classes (`.my-about-page`), and uses PascalCasing for JavaScript classes in ES6/TypeScript (`MyAboutPage`). Using this convention, developers can pick up any Ionic 2 project and quickly become productive, similar to Rails.


### PR DESCRIPTION
Intrigued by ['kebob case'](https://ionicframework.com/docs/v2/cli/generate/#a-quick-note-on-naming-conventions), I went looking for a reference. 

Seems like there's no [universal convention](https://stackoverflow.com/questions/11273282/whats-the-name-for-hyphen-separated-case) for what this is called, but ['kebab'](https://en.wikipedia.org/wiki/Kebab_case) works and 'kebob' is a typo.